### PR TITLE
Fix bug in `random-int`

### DIFF
--- a/src/propeller/problems/software/number_io.cljc
+++ b/src/propeller/problems/software/number_io.cljc
@@ -37,7 +37,7 @@
 (defn random-float [] (- (* (rand) 200) 100.0))
 
 ; Random integer between -100 and 100
-(defn random-int [] (- (rand-int 201) 100.0))
+(defn random-int [] (- (rand-int 201) 100))
 
 (def instructions
   (utils/not-lazy

--- a/src/propeller/problems/software/smallest.cljc
+++ b/src/propeller/problems/software/smallest.cljc
@@ -38,7 +38,7 @@
 ;; =============================================================================
 
 ; Random integer between -100 and 100
-(defn random-int [] (- (rand-int 201) 100.0))
+(defn random-int [] (- (rand-int 201) 100))
 
 (def instructions
   (utils/not-lazy


### PR DESCRIPTION
The `random-int` function in both `number-io` and `smallest` subtracted a floating point value (`100.0`), which means they were both _actually_ returning a float instead of an int.

This removes both of the ".0"s so that they return integers as advertised.