### PR TITLE
Support command-line problem specification

### DIFF
--- a/src/propeller/core.cljc
+++ b/src/propeller/core.cljc
@@ -3,18 +3,26 @@
   (:require [propeller.gp :as gp]
             [propeller.problems.simple-regression :as regression]
             [propeller.problems.string-classification :as string-classif]
-            [propeller.problems.software.number-io :as number-io]
-            [propeller.problems.software.smallest :as smallest]
             #?(:cljs [cljs.reader :refer [read-string]])))
+
+(defn eval-problem-var
+  [problem-name var-name]
+  (eval (symbol (str "propeller.problems." problem-name "/" var-name))))
 
 (defn -main
   "Runs propel-gp, giving it a map of arguments."
   [& args]
+  (when (empty? args)
+    (println "You must specify a problem to run.")
+    (println "Try, for example:")
+    (println "   lein run software.smallest")
+    (System/exit 1))
+  (require (symbol (str "propeller.problems." (first args))))
   (gp/gp
     (update-in
       (merge
-        {:instructions            number-io/instructions
-         :error-function          number-io/error-function
+        {:instructions            (eval-problem-var (first args) "instructions")
+         :error-function          (eval-problem-var (first args) "error-function")
          :max-generations         500
          :population-size         500
          :max-initial-plushy-size 100
@@ -25,6 +33,6 @@
          :variation               {:umad 0.5 :crossover 0.5}
          :elitism                 false}
         (apply hash-map
-               (map read-string args)))
+               (map read-string (rest args))))
       [:error-function]
       identity)))


### PR DESCRIPTION
This change uses the first command-line argument as the problem, which is assumed to be a namespace under `propeller.problems`. This will load the `instructions` and `error-function` from that namespace. If no problem is specified, then a (hopefully) helpful error is generated and the programs exits.

This allows us to call Propeller with calls such as:

```
   lein run software.smallest
```