### PR TITLE
Add tests for vector instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ pom.xml.asc
 out
 notes
 .idea/
+.calva/
+
+# Don't commit the data directory that we'll
+# use to hold the data from
+# https://github.com/thelmuth/program-synthesis-benchmark-datasets
+/data

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ pom.xml.asc
 .idea/
 out
 notes
+.clj-kondo/
 .idea/
 .calva/
 

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "EPL-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0"
             :url  "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [org.clojure/clojurescript "1.9.946"]]
+                 [org.clojure/clojurescript "1.9.946"]
+                 [org.clojure/test.check "1.1.0"]]
   :main ^:skip-aot propeller.core
   :repl-options {:init-ns propeller.core})

--- a/src/propeller/push/instructions/vector.cljc
+++ b/src/propeller/push/instructions/vector.cljc
@@ -183,7 +183,10 @@
     (let [lit-stack (get-vector-literal-type stack)]
       (make-instruction state
                         (fn [lit1 lit2 vect]
-                          (assoc vect (utils/indexof lit1 vect) lit2))
+                          (let [replaceindex (utils/indexof lit1 vect)]
+                            (if (= replaceindex -1)
+                              :ignore-instruction
+                              (assoc vect replaceindex lit2))))
                         [lit-stack lit-stack stack]
                         stack))))
 

--- a/src/propeller/push/instructions/vector.cljc
+++ b/src/propeller/push/instructions/vector.cljc
@@ -211,8 +211,10 @@
     (let [lit-stack (get-vector-literal-type stack)]
       (make-instruction state
                         (fn [lit n vect]
-                          (assoc vect (mod n (count vect)) lit))
-                        [:integer lit-stack stack]
+                          (if (empty? vect)
+                            :ignore-instruction
+                            (assoc vect (mod n (count vect)) lit)))
+                        [lit-stack :integer stack]
                         stack))))
 
 ;; Pushes a subvector of the top item, with start and end indices determined by

--- a/src/propeller/push/instructions/vector.cljc
+++ b/src/propeller/push/instructions/vector.cljc
@@ -185,7 +185,7 @@
                         (fn [lit1 lit2 vect]
                           (let [replaceindex (utils/indexof lit1 vect)]
                             (if (= replaceindex -1)
-                              :ignore-instruction
+                              vect
                               (assoc vect replaceindex lit2))))
                         [lit-stack lit-stack stack]
                         stack))))

--- a/src/propeller/push/instructions/vector.cljc
+++ b/src/propeller/push/instructions/vector.cljc
@@ -121,7 +121,9 @@
   (fn [stack state]
     (let [lit-stack (get-vector-literal-type stack)]
       (make-instruction state
-                        #(get %2 (mod %1 (count %2)))
+                        #(if (empty? %2)
+                           :ignore-instruction
+                           (get %2 (mod %1 (count %2))))
                         [:integer stack]
                         lit-stack))))
 

--- a/src/propeller/push/instructions/vector.cljc
+++ b/src/propeller/push/instructions/vector.cljc
@@ -52,12 +52,16 @@
     (make-instruction state empty? [stack] :boolean)))
 
 ;; Pushes the first item of the top element of the vector stack onto the
-;; approrpiately-typed literal stack
+;; approrpiately-typed literal stack. If the vector is empty, return
+;; :ignore-instruction so that nothing is changed on the stacks.
 (def _first
   ^{:stacks #{:elem}}
   (fn [stack state]
     (let [lit-stack (get-vector-literal-type stack)]
-      (make-instruction state first [stack] lit-stack))))
+      (make-instruction state
+                        #(if (empty? %) :ignore-instruction (first %))
+                        [stack] 
+                        lit-stack))))
 
 ;; Pushes onto the INTEGER stack the index of the top element of the
 ;; appropriately-typed literal stack within the top element of the vector stack

--- a/src/propeller/push/instructions/vector.cljc
+++ b/src/propeller/push/instructions/vector.cljc
@@ -52,7 +52,7 @@
     (make-instruction state empty? [stack] :boolean)))
 
 ;; Pushes the first item of the top element of the vector stack onto the
-;; approrpiately-typed literal stack. If the vector is empty, return
+;; appropriately-typed literal stack. If the vector is empty, return
 ;; :ignore-instruction so that nothing is changed on the stacks.
 (def _first
   ^{:stacks #{:elem}}
@@ -101,7 +101,11 @@
   ^{:stacks #{:elem}}
   (fn [stack state]
     (let [lit-stack (get-vector-literal-type stack)]
-      (make-instruction state last [stack] lit-stack))))
+      (make-instruction 
+       state 
+       #(if (empty? %) :ignore-instruction (last %)) 
+       [stack] 
+       lit-stack))))
 
 ;; Pushes the length of the top item onto the INTEGER stack
 (def _length

--- a/src/propeller/push/instructions/vector.cljc
+++ b/src/propeller/push/instructions/vector.cljc
@@ -208,9 +208,9 @@
   ^{:stacks #{:integer}}
   (fn [stack state]
     (make-instruction state
-                      (fn [stop-raw start-raw vect]
+                      (fn [start-raw stop-raw vect]
                         (let [start (min (count vect) (max 0 start-raw))
-                              stop (min (count vect) (max start-raw stop-raw))]
+                              stop (min (count vect) (max 0 start-raw stop-raw))]
                           (subvec vect start stop)))
                       [:integer :integer stack]
                       stack)))

--- a/src/propeller/push/utils/helpers.cljc
+++ b/src/propeller/push/utils/helpers.cljc
@@ -28,7 +28,11 @@
 ;; A utility function for making Push instructions. Takes a state, a function
 ;; to apply to the args, the stacks to take the args from, and the stack to
 ;; return the result to. Applies the function to the args (popped from the
-;; given stacks), and pushes the result onto the return-stack
+;; given stacks), and pushes the result onto the return-stack.
+;;
+;; If the function returns :ignore-instruction, then we will return the
+;; initial state unchanged. This allows instructions to fail gracefully
+;; without consuming stack values.
 (defn make-instruction
   [state function arg-stacks return-stack]
   (let [popped-args (get-args-from-stacks state arg-stacks)]
@@ -36,7 +40,9 @@
       state
       (let [result (apply function (:args popped-args))
             new-state (:state popped-args)]
-        (state/push-to-stack new-state return-stack result)))))
+        (if (= result :ignore-instruction)
+          state
+         (state/push-to-stack new-state return-stack result))))))
 
 ;; Given a set of stacks, returns all instructions that operate on those stacks
 ;; only. Won't include random instructions unless :random is in the set as well

--- a/test/propeller/core_test.clj
+++ b/test/propeller/core_test.clj
@@ -2,6 +2,6 @@
   (:require [clojure.test :refer :all]
             [propeller.core :refer :all]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 0 1))))
+;; (deftest a-test
+;;   (testing "FIXME, I fail."
+;;     (is (= 0 1))))

--- a/test/propeller/core_test.clj
+++ b/test/propeller/core_test.clj
@@ -1,7 +1,0 @@
-(ns propeller.core-test
-  (:require [clojure.test :refer :all]
-            [propeller.core :refer :all]))
-
-;; (deftest a-test
-;;   (testing "FIXME, I fail."
-;;     (is (= 0 1))))

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -12,15 +12,45 @@
    ['gen/boolean "boolean"]
    ['gen/string "string"]])
 
+(defn generator-for-arg-type
+  [arg-type generator]
+  (case arg-type
+    :boolean 'gen/boolean
+    :integer 'gen/small-integer
+    :float   'gen/double
+    :string  'gen/string
+    ; This is for "generic" vectors where the element is provided by
+    ; the `generator` argument.
+    :vector  `(gen/vector ~generator)
+    :item    generator
+    :vector_boolean '(gen/vector gen/boolean)
+    :vector_integer '(gen/vector gen/small-integer)
+    :vector_float   '(gen/vector gen/double)
+    :vector_string  '(gen/vector gen/string)))
+
+(defmacro gen-specs
+  [spec-name check-fn & arg-types]
+  (let [symbol-names (repeatedly (count arg-types) gensym)]
+    `(do ~@(for [[generator value-type] gen-type-pairs
+                 :let [name (symbol (str spec-name "-spec-" value-type))]]
+             `(defspec ~name
+                (prop/for-all
+                 [~@(mapcat
+                     (fn [symbol-name arg-type]
+                       [symbol-name (generator-for-arg-type arg-type generator)])
+                     symbol-names
+                     arg-types)]
+                 (~check-fn ~value-type ~@symbol-names)))))))
+
 ;;; vector/_contains
 
-(defn check-expected-contains
+(defn check-contains
   "Creates an otherwise empty Push state with the given vector on the
    appropriate vector stack (assumed to be :vector_<value-type>), and
    the given value on the appropriate stack (determined by value-type).
    It then runs the vector/_contains instruction, and confirms that the
    result (on the :boolean stack) is the expected value."
-  [vect value value-type]
+  [value-type vect value]
   (let [stack-type (keyword (str "vector_" value-type))
         start-state (state/push-to-stack
                      (state/push-to-stack state/empty-state
@@ -28,36 +58,16 @@
                                           vect)
                      (keyword value-type) value)
         end-state (vector/_contains stack-type start-state)
-        expected-result (not (= (.indexOf vect value) -1))]
+        expected-result (not= (.indexOf vect value) -1)]
     (= expected-result
        (state/peek-stack end-state :boolean))))
 
-(defmacro contains-vector-spec
-  [generator value-type]
-  `(do
-     (defspec ~(symbol (str "contains-vector-spec-" value-type))
-       ; Should this be smaller for booleans? (Ditto for below.)
-       100
-       (prop/for-all [vect# (gen/vector ~generator)
-                      value# ~generator]
-                     (check-expected-contains vect# value# ~value-type)))
-       ; For float and string vectors, it's rather rare to actually have a random value that
-       ; appears in the vector, so we don't consistently test the case where it should 
-       ; return TRUE. So maybe we do need a separate test for those? 
-     (defspec ~(symbol (str "contains-vector-spec-has-value-" value-type))
-       100
-       (prop/for-all [vect# (gen/not-empty (gen/vector ~generator))]
-                     (check-expected-contains vect# (rand-nth vect#) ~value-type)))))
-
-(contains-vector-spec gen/small-integer "integer")
-(contains-vector-spec gen/double "float")
-(contains-vector-spec gen/boolean "boolean")
-(contains-vector-spec gen/string "string")
+(gen-specs "contains" check-contains :vector :item)
 
 ;;; vector/_emptyvector
 
 (defn check-empty-vector
-  [vect value-type]
+  [value-type vect]
   (let [stack-type (keyword (str "vector_" value-type))
         start-state (state/push-to-stack state/empty-state
                                          stack-type
@@ -66,22 +76,12 @@
     (= (empty? vect)
        (state/peek-stack end-state :boolean))))
 
-(defmacro empty-vector-spec
-  [generator value-type]
-  `(defspec ~(symbol (str "empty-vector-spec-" value-type))
-     100
-     (prop/for-all [vect# (gen/vector ~generator)]
-                   (check-empty-vector vect# ~value-type))))
-
-(empty-vector-spec gen/small-integer "integer")
-(empty-vector-spec gen/double "float")
-(empty-vector-spec gen/boolean "boolean")
-(empty-vector-spec gen/string "string")
+(gen-specs "empty-vector" check-empty-vector :vector)
 
 ;;; vector/_first
 
 (defn check-first
-  [vect value-type]
+  [value-type vect]
   (let [stack-type (keyword (str "vector_" value-type))
         start-state (state/push-to-stack state/empty-state
                                          stack-type
@@ -96,22 +96,12 @@
          (state/peek-stack end-state (keyword value-type)))
       (state/empty-stack? end-state stack-type)))))
 
-(defmacro first-spec
-  [generator value-type]
-  `(defspec ~(symbol (str "first-spec-" value-type))
-     100
-     (prop/for-all [vect# (gen/vector ~generator)]
-                   (check-first vect# ~value-type))))
-
-(first-spec gen/small-integer "integer")
-(first-spec gen/double "float")
-(first-spec gen/boolean "boolean")
-(first-spec gen/string "string")
+(gen-specs "first" check-first :vector)
 
 ;;; vector/_last
 
 (defn check-last
-  [vect value-type]
+  [value-type vect]
   (let [stack-type (keyword (str "vector_" value-type))
         start-state (state/push-to-stack state/empty-state
                                          stack-type
@@ -126,27 +116,17 @@
          (state/peek-stack end-state (keyword value-type)))
       (state/empty-stack? end-state stack-type)))))
 
-(defmacro last-spec
-  [generator value-type]
-  `(defspec ~(symbol (str "last-spec-" value-type))
-     100
-     (prop/for-all [vect# (gen/vector ~generator)]
-                   (check-last vect# ~value-type))))
-
-(last-spec gen/small-integer "integer")
-(last-spec gen/double "float")
-(last-spec gen/boolean "boolean")
-(last-spec gen/string "string")
+(gen-specs "last" check-last :vector)
 
 ;;; vector/_indexof
 
-(defn check-expected-index
+(defn check-indexof
   "Creates an otherwise empty Push state with the given vector on the
    appropriate vector stack (assumed to be :vector_<value-type>), and
    the given value on the appropriate stack (determined by value-type).
    It then runs the vector/_indexof instruction, and confirms that the
    result (on the :integer stack) is the expected value."
-  [vect value value-type]
+  [value-type vect value]
   (let [stack-type (keyword (str "vector_" value-type))
         start-state (state/push-to-stack
                      (state/push-to-stack state/empty-state
@@ -158,27 +138,7 @@
     (= expected-index
        (state/peek-stack end-state :integer))))
 
-(defmacro indexof-spec
-  [generator value-type]
-  `(do
-     (defspec ~(symbol (str "indexof-spec-" value-type))
-       ; Should this be smaller for booleans? (Ditto for below.)
-       100
-       (prop/for-all [vect# (gen/vector ~generator)
-                      value# ~generator]
-                     (check-expected-index vect# value# ~value-type)))
-       ; For float and string vectors, it's rather rare to actually have a random value that
-       ; appears in the vector, so we don't consistently test the case where it should 
-       ; return -1. So maybe we do need a separate test for those? 
-     (defspec ~(symbol (str "indexof-spec-has-value-" value-type))
-       100
-       (prop/for-all [vect# (gen/not-empty (gen/vector ~generator))]
-                     (check-expected-index vect# (rand-nth vect#) ~value-type)))))
-
-(indexof-spec gen/small-integer "integer")
-(indexof-spec gen/double "float")
-(indexof-spec gen/boolean "boolean")
-(indexof-spec gen/string "string")
+(gen-specs "indexof" check-indexof :vector :item)
 
 ;;; vector/_concat
 
@@ -201,16 +161,7 @@
     (= (concat second-vect first-vect)
        (state/peek-stack end-state stack-type))))
 
-(defmacro concat-spec
-  []
-  `(do ~@(for [[generator value-type] gen-type-pairs
-               :let [name (symbol (str "concat-spec-" value-type))]]
-           `(defspec ~name
-              (prop/for-all [first-vect#  (gen/vector ~generator)
-                             second-vect# (gen/vector ~generator)]
-                            (check-concat first-vect# second-vect# ~value-type))))))
-
-; (concat-spec)
+(gen-specs "concat" check-concat :vector :vector)
 
 ;;; vector/_subvec
 
@@ -244,47 +195,4 @@
     (= expected-subvec
        (state/peek-stack end-state stack-type))))
 
-(defmacro subvec-spec
-  []
-  `(do ~@(for [[generator value-type] gen-type-pairs
-               :let [name (symbol (str "subvec-spec-" value-type))]]
-           `(defspec ~name
-              (prop/for-all [vect# (gen/vector ~generator)
-                             start# gen/small-integer
-                             stop# gen/small-integer]
-                            (check-subvec vect# start# stop# ~value-type))))))
-
-; (subvec-spec)
-
-(defn generator-for-arg-type
-  [arg-type generator]
-  (case arg-type
-    :boolean 'gen/boolean
-    :integer 'gen/small-integer
-    :float   'gen/double
-    :string  'gen/string
-    ; This is for "generic" vectors where the element is provided by
-    ; the `generator` argument.
-    :vector  `(gen/vector ~generator)
-    :vector_boolean '(gen/vector gen/boolean)
-    :vector_integer '(gen/vector gen/small-integer)
-    :vector_float   '(gen/vector gen/double)
-    :vector_string  '(gen/vector gen/string)
-    ))
-
-(defmacro gen-specs
-  [spec-name check-fn & arg-types]
-  (let [symbol-names (repeatedly (count arg-types) gensym)]
-  `(do ~@(for [[generator value-type] gen-type-pairs
-               :let [name (symbol (str spec-name "-spec-" value-type))]]
-           `(defspec ~name
-              (prop/for-all
-               [~@(mapcat 
-                   (fn [symbol-name arg-type]
-                    [symbol-name (generator-for-arg-type arg-type generator)])
-                   symbol-names
-                   arg-types) ]
-               (~check-fn ~value-type ~@symbol-names)))))))
-
-(gen-specs "concat" check-concat :vector :vector)
 (gen-specs "subvec" check-subvec :vector :integer :integer)

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -57,6 +57,47 @@
 
 (gen-specs "butlast" check-butlast :vector)
 
+;;; vector/_concat
+
+(defn check-concat
+  "Creates an otherwise empty Push state with the two given vectors on the
+   appropriate vector stack (assumed to be :vector_<value-type>).
+   It then runs the vector/_concat instruction, and confirms that the
+   result (on the :vector_<value-type> stack) is the expected value.
+   The order of concatenation is that the top of the stack will be
+   _second_ in the concatenation, i.e., its elements will come _after_
+   the elements in the vector one below it in the stack."
+  [value-type first-vect second-vect]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack
+                     (state/push-to-stack state/empty-state
+                                          stack-type
+                                          first-vect)
+                     stack-type second-vect)
+        end-state (vector/_concat stack-type start-state)]
+    (= (concat second-vect first-vect)
+       (state/peek-stack end-state stack-type))))
+
+(gen-specs "concat" check-concat :vector :vector)
+
+;;; vecotr/_conj
+
+(defn check-conj
+  [value-type vect value]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack
+                     (state/push-to-stack state/empty-state
+                                          stack-type
+                                          vect)
+                     (keyword (str value-type))
+                     value)
+        end-state (vector/_conj stack-type start-state)
+        expected-result (conj vect value)]
+    (= expected-result
+       (state/peek-stack end-state stack-type))))
+
+(gen-specs "conj" check-conj :vector :item)
+
 ;;; vector/_contains
 
 (defn check-contains
@@ -154,29 +195,6 @@
        (state/peek-stack end-state :integer))))
 
 (gen-specs "indexof" check-indexof :vector :item)
-
-;;; vector/_concat
-
-(defn check-concat
-  "Creates an otherwise empty Push state with the two given vectors on the
-   appropriate vector stack (assumed to be :vector_<value-type>).
-   It then runs the vector/_concat instruction, and confirms that the
-   result (on the :vector_<value-type> stack) is the expected value.
-   The order of concatenation is that the top of the stack will be
-   _second_ in the concatenation, i.e., its elements will come _after_
-   the elements in the vector one below it in the stack."
-  [value-type first-vect second-vect]
-  (let [stack-type (keyword (str "vector_" value-type))
-        start-state (state/push-to-stack
-                     (state/push-to-stack state/empty-state
-                                          stack-type
-                                          first-vect)
-                     stack-type second-vect)
-        end-state (vector/_concat stack-type start-state)]
-    (= (concat second-vect first-vect)
-       (state/peek-stack end-state stack-type))))
-
-(gen-specs "concat" check-concat :vector :vector)
 
 ;;; vector/_subvec
 

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -338,6 +338,21 @@
 
 (gen-specs "replacefirst" check-replacefirst :vector :item :item)
 
+;;; vector/_rest
+
+(defn check-rest
+  [value-type vect]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack state/empty-state
+                                         stack-type
+                                         vect)
+        end-state (vector/_rest stack-type start-state)
+        expected-result (vec (rest vect))]
+    (= expected-result
+       (state/peek-stack end-state stack-type))))
+
+(gen-specs "rest" check-rest :vector)
+
 ;;; vector/_subvec
 
 (defn clean-subvec-bounds

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -6,6 +6,8 @@
    [propeller.push.state :as state]
    [propeller.push.instructions.vector :as vector]))
 
+;;; vector/_emptyvector
+
 (defn check-empty-vector
   [generator value-type]
   (let [stack-type (keyword (str "vector_" value-type))]
@@ -27,6 +29,38 @@
 (empty-vector-spec gen/double "float")
 (empty-vector-spec gen/boolean "boolean")
 (empty-vector-spec gen/string "string")
+
+;;; vector/_first
+
+(defn check-first
+  [generator value-type]
+  (let [stack-type (keyword (str "vector_" value-type))]
+    (prop/for-all [vect (gen/vector generator)]
+                  (let [start-state (state/push-to-stack state/empty-state
+                                                         stack-type
+                                                         vect)
+                        end-state (vector/_first stack-type start-state)]
+                    (or
+                     (and (empty? vect)
+                          (= (state/peek-stack end-state stack-type)
+                             vect))
+                     (and
+                      (= (first vect)
+                         (state/peek-stack end-state (keyword value-type)))
+                      (state/empty-stack? end-state stack-type)))))))
+
+(defmacro first-spec
+  [generator value-type]
+  `(defspec ~(symbol (str "first-spec-" value-type))
+     100
+     (check-first ~generator ~value-type)))
+
+(first-spec gen/small-integer "integer")
+(first-spec gen/double "float")
+(first-spec gen/boolean "boolean")
+(first-spec gen/string "string")
+
+;;; vector/_indexof
 
 (defn check-expected-index
   "Creates an otherwise empty Push state with the given vector on the
@@ -67,6 +101,8 @@
 (indexof-spec gen/double "float")
 (indexof-spec gen/boolean "boolean")
 (indexof-spec gen/string "string")
+
+;;; vector/_subvec
 
 (defn clean-subvec-bounds
   [start stop vect-size]

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -353,6 +353,21 @@
 
 (gen-specs "rest" check-rest :vector)
 
+;;; vector/_reverse
+
+(defn check-reverse
+  [value-type vect]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack state/empty-state
+                                         stack-type
+                                         vect)
+        end-state (vector/_reverse stack-type start-state)
+        expected-result (vec (rest vect))]
+    (= expected-result
+       (state/peek-stack end-state stack-type))))
+
+(gen-specs "reverse" check-reverse :vector)
+
 ;;; vector/_subvec
 
 (defn clean-subvec-bounds

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -60,6 +60,36 @@
 (first-spec gen/boolean "boolean")
 (first-spec gen/string "string")
 
+;;; vector/_last
+
+(defn check-last
+  [generator value-type]
+  (let [stack-type (keyword (str "vector_" value-type))]
+    (prop/for-all [vect (gen/vector generator)]
+                  (let [start-state (state/push-to-stack state/empty-state
+                                                         stack-type
+                                                         vect)
+                        end-state (vector/_last stack-type start-state)]
+                    (or
+                     (and (empty? vect)
+                          (= (state/peek-stack end-state stack-type)
+                             vect))
+                     (and
+                      (= (last vect)
+                         (state/peek-stack end-state (keyword value-type)))
+                      (state/empty-stack? end-state stack-type)))))))
+
+(defmacro last-spec
+  [generator value-type]
+  `(defspec ~(symbol (str "last-spec-" value-type))
+     100
+     (check-last ~generator ~value-type)))
+
+(last-spec gen/small-integer "integer")
+(last-spec gen/double "float")
+(last-spec gen/boolean "boolean")
+(last-spec gen/string "string")
+
 ;;; vector/_indexof
 
 (defn check-expected-index

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -211,6 +211,28 @@
 
 (gen-specs "length" check-length :vector)
 
+;;; vector/_nth
+
+(defn check-nth
+  [value-type vect n]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack
+                     (state/push-to-stack state/empty-state
+                                          stack-type
+                                          vect)
+                     :integer
+                     n)
+        end-state (vector/_nth stack-type start-state)]
+    (or
+     (and (empty? vect)
+          (= (state/peek-stack end-state stack-type)
+             vect))
+     (and 
+          (= (get vect (mod n (count vect)))
+             (state/peek-stack end-state (keyword value-type)))))))
+
+(gen-specs "nth" check-nth :vector :integer)
+
 ;;; vector/_subvec
 
 (defn clean-subvec-bounds

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -368,6 +368,36 @@
 
 (gen-specs "reverse" check-reverse :vector)
 
+;;; vector/_set
+
+(defn check-set
+  [value-type vect value n]
+  (let [stack-type (keyword (str "vector_" value-type))
+        value-stack (keyword value-type)
+        start-state (state/push-to-stack
+                      (state/push-to-stack
+                        (state/push-to-stack state/empty-state
+                                             stack-type
+                                             vect)
+                        value-stack
+                        value)
+                      :integer
+                      n)
+        end-state (vector/_set stack-type start-state)]
+    (or
+     (and
+      (empty? vect)
+      (not (state/empty-stack? end-state :integer))
+      (not (state/empty-stack? end-state value-stack))
+      (= vect (state/peek-stack end-state stack-type)))
+     (and
+      (= (state/peek-stack end-state stack-type)
+         (assoc vect (mod n (count vect)) value))
+      (state/empty-stack? end-state :integer)
+      (state/empty-stack? end-state value-stack)))))
+
+(gen-specs "set" check-set :vector :item :integer)
+
 ;;; vector/_subvec
 
 (defn clean-subvec-bounds

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -362,7 +362,7 @@
                                          stack-type
                                          vect)
         end-state (vector/_reverse stack-type start-state)
-        expected-result (vec (rest vect))]
+        expected-result (vec (reverse vect))]
     (= expected-result
        (state/peek-stack end-state stack-type))))
 

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -289,6 +289,28 @@
 
 (gen-specs "remove" check-remove :vector :item)
 
+;;; vector/_replace
+
+(defn check-replace
+  [value-type vect toreplace replacement]
+  (let [stack-type (keyword (str "vector_" value-type))
+        value-stack (keyword value-type)
+        start-state (state/push-to-stack
+                     (state/push-to-stack
+                      (state/push-to-stack state/empty-state
+                                           stack-type
+                                           vect)
+                      value-stack
+                      toreplace)
+                     value-stack
+                     replacement)
+        end-state (vector/_replace stack-type start-state)
+        expected-result (replace {toreplace replacement} vect)]
+    (= expected-result
+       (state/peek-stack end-state stack-type))))
+
+(gen-specs "replace" check-replace :vector :item :item)
+
 ;;; vector/_subvec
 
 (defn clean-subvec-bounds

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -6,6 +6,12 @@
    [propeller.push.state :as state]
    [propeller.push.instructions.vector :as vector]))
 
+(def gen-type-pairs
+  [['gen/small-integer "integer"]
+   ['gen/double "float"]
+   ['gen/boolean "boolean"]
+   ['gen/string "string"]])
+
 ;;; vector/_emptyvector
 
 (defn check-empty-vector
@@ -154,17 +160,15 @@
        (state/peek-stack end-state stack-type))))
 
 (defmacro concat-spec
-  [generator value-type]
-  `(defspec ~(symbol (str "concat-spec-" value-type))
-     100
-     (prop/for-all [first-vect#  (gen/vector ~generator)
-                    second-vect# (gen/vector ~generator)]
-                   (check-concat first-vect# second-vect# ~value-type))))
+  []
+  `(do ~@(for [[generator value-type] gen-type-pairs
+               :let [name (symbol (str "concat-spec-" value-type))]]
+           `(defspec ~name
+              (prop/for-all [first-vect#  (gen/vector ~generator)
+                             second-vect# (gen/vector ~generator)]
+                            (check-concat first-vect# second-vect# ~value-type))))))
 
-(concat-spec gen/small-integer "integer")
-(concat-spec gen/double "float")
-(concat-spec gen/boolean "boolean")
-(concat-spec gen/string "string")
+(concat-spec)
 
 ;;; vector/_subvec
 
@@ -199,14 +203,13 @@
        (state/peek-stack end-state stack-type))))
 
 (defmacro subvec-spec
-  [generator value-type]
-  `(defspec ~(symbol (str "subvec-spec-" value-type))
-     (prop/for-all [vect# (gen/vector ~generator)
-                    start# gen/small-integer
-                    stop# gen/small-integer]
-                   (check-subvec vect# start# stop# ~value-type))))
+  []
+  `(do ~@(for [[generator value-type] gen-type-pairs
+               :let [name (symbol (str "subvec-spec-" value-type))]]
+           `(defspec ~name
+              (prop/for-all [vect# (gen/vector ~generator)
+                             start# gen/small-integer
+                             stop# gen/small-integer]
+                            (check-subvec vect# start# stop# ~value-type))))))
 
-(subvec-spec gen/small-integer "integer")
-(subvec-spec gen/double "float")
-(subvec-spec gen/boolean "boolean")
-(subvec-spec gen/string "string")
+(subvec-spec)

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -42,6 +42,21 @@
                      arg-types)]
                  (~check-fn ~value-type ~@symbol-names)))))))
 
+;;; vector/_butlast
+
+(defn check-butlast
+  [value-type vect]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack state/empty-state
+                                         stack-type
+                                         vect)
+        end-state (vector/_butlast stack-type start-state)
+        expected-result (vec (butlast vect))]
+    (= expected-result
+       (state/peek-stack end-state stack-type))))
+
+(gen-specs "butlast" check-butlast :vector)
+
 ;;; vector/_contains
 
 (defn check-contains

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -331,7 +331,7 @@
         replacement-index (.indexOf vect toreplace)]
     (or
      (and (= replacement-index -1)
-          (= [replacement toreplace] (state/peek-stack-many end-state value-stack 2))
+          (state/empty-stack? end-state value-stack)
           (= vect end-vector))
      (and (state/empty-stack? end-state value-stack)
           (= end-vector (assoc vect replacement-index replacement))))))

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -233,6 +233,24 @@
 
 (gen-specs "nth" check-nth :vector :integer)
 
+;;; vector/_occurrencesof
+
+(defn check-occurrencesof
+  [value-type vect value]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack
+                     (state/push-to-stack state/empty-state
+                                          stack-type
+                                          vect)
+                     (keyword value-type)
+                     value)
+        end-state (vector/_occurrencesof stack-type start-state)
+        expected-result (count (filterv #(= value %) vect))]
+    (= expected-result
+       (state/peek-stack end-state :integer))))
+
+(gen-specs "occurrencesof" check-occurrencesof :vector :item)
+
 ;;; vector/_subvec
 
 (defn clean-subvec-bounds

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -272,6 +272,23 @@
 
 (gen-specs "pushall" check-pushall :vector)
 
+;;; vector/_remove
+
+(defn check-remove
+  [value-type vect value]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack
+                     (state/push-to-stack state/empty-state
+                                          stack-type
+                                          vect)
+                     (keyword value-type)
+                     value)
+        end-state (vector/_remove stack-type start-state)]
+    (= []
+       (filterv #(= % value) (state/peek-stack end-state stack-type)))))
+
+(gen-specs "remove" check-remove :vector :item)
+
 ;;; vector/_subvec
 
 (defn clean-subvec-bounds

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -431,3 +431,21 @@
        (state/peek-stack end-state stack-type))))
 
 (gen-specs "subvec" check-subvec :vector :integer :integer)
+
+;;; vector/_take
+
+(defn check-take
+  [value-type vect n]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack
+                     (state/push-to-stack state/empty-state
+                                          stack-type
+                                          vect)
+                     :integer
+                     n)
+        end-state (vector/_take stack-type start-state)
+        expected-result (vec (take n vect))]
+    (= expected-result
+       (state/peek-stack end-state stack-type))))
+
+(gen-specs "take" check-take :vector :integer)

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -311,6 +311,33 @@
 
 (gen-specs "replace" check-replace :vector :item :item)
 
+;;; vector/_replacefirst
+
+(defn check-replacefirst
+  [value-type vect toreplace replacement]
+  (let [stack-type (keyword (str "vector_" value-type))
+        value-stack (keyword value-type)
+        start-state (state/push-to-stack
+                     (state/push-to-stack
+                      (state/push-to-stack state/empty-state
+                                           stack-type
+                                           vect)
+                      value-stack
+                      toreplace)
+                     value-stack
+                     replacement)
+        end-state (vector/_replacefirst stack-type start-state)
+        end-vector (state/peek-stack end-state stack-type)
+        replacement-index (.indexOf vect toreplace)]
+    (or
+     (and (= replacement-index -1)
+          (= [replacement toreplace] (state/peek-stack-many end-state value-stack 2))
+          (= vect end-vector))
+     (and (state/empty-stack? end-state value-stack)
+          (= end-vector (assoc vect replacement-index replacement))))))
+
+(gen-specs "replacefirst" check-replacefirst :vector :item :item)
+
 ;;; vector/_subvec
 
 (defn clean-subvec-bounds

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -251,6 +251,27 @@
 
 (gen-specs "occurrencesof" check-occurrencesof :vector :item)
 
+;;; vector/_pushall
+
+(defn check-pushall
+  [value-type vect]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack state/empty-state
+                                         stack-type
+                                         vect)
+        end-state (vector/_pushall stack-type start-state)
+        value-stack (keyword value-type)
+        vect-length (count vect)]
+    (and
+       (=
+          (vec (state/peek-stack-many end-state value-stack vect-length))
+          vect)
+       (state/empty-stack?
+          (state/pop-stack-many end-state value-stack vect-length)
+          value-stack))))
+
+(gen-specs "pushall" check-pushall :vector)
+
 ;;; vector/_subvec
 
 (defn clean-subvec-bounds

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -57,21 +57,21 @@
 ;;; vector/_emptyvector
 
 (defn check-empty-vector
-  [generator value-type]
-  (let [stack-type (keyword (str "vector_" value-type))]
-    (prop/for-all [vect (gen/vector generator)]
-                  (let [start-state (state/push-to-stack state/empty-state
-                                                         stack-type
-                                                         vect)
-                        end-state (vector/_emptyvector stack-type start-state)]
-                    (= (empty? vect)
-                       (state/peek-stack end-state :boolean))))))
+  [vect value-type]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack state/empty-state
+                                         stack-type
+                                         vect)
+        end-state (vector/_emptyvector stack-type start-state)]
+    (= (empty? vect)
+       (state/peek-stack end-state :boolean))))
 
 (defmacro empty-vector-spec
   [generator value-type]
-    `(defspec ~(symbol (str "empty-vector-spec-" value-type))
-       100
-       (check-empty-vector ~generator ~value-type)))
+  `(defspec ~(symbol (str "empty-vector-spec-" value-type))
+     100
+     (prop/for-all [vect# (gen/vector ~generator)]
+                   (check-empty-vector vect# ~value-type))))
 
 (empty-vector-spec gen/small-integer "integer")
 (empty-vector-spec gen/double "float")
@@ -81,27 +81,27 @@
 ;;; vector/_first
 
 (defn check-first
-  [generator value-type]
-  (let [stack-type (keyword (str "vector_" value-type))]
-    (prop/for-all [vect (gen/vector generator)]
-                  (let [start-state (state/push-to-stack state/empty-state
-                                                         stack-type
-                                                         vect)
-                        end-state (vector/_first stack-type start-state)]
-                    (or
-                     (and (empty? vect)
-                          (= (state/peek-stack end-state stack-type)
-                             vect))
-                     (and
-                      (= (first vect)
-                         (state/peek-stack end-state (keyword value-type)))
-                      (state/empty-stack? end-state stack-type)))))))
+  [vect value-type]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack state/empty-state
+                                         stack-type
+                                         vect)
+        end-state (vector/_first stack-type start-state)]
+    (or
+     (and (empty? vect)
+          (= (state/peek-stack end-state stack-type)
+             vect))
+     (and
+      (= (first vect)
+         (state/peek-stack end-state (keyword value-type)))
+      (state/empty-stack? end-state stack-type)))))
 
 (defmacro first-spec
   [generator value-type]
   `(defspec ~(symbol (str "first-spec-" value-type))
      100
-     (check-first ~generator ~value-type)))
+     (prop/for-all [vect# (gen/vector ~generator)]
+                   (check-first vect# ~value-type))))
 
 (first-spec gen/small-integer "integer")
 (first-spec gen/double "float")
@@ -111,27 +111,27 @@
 ;;; vector/_last
 
 (defn check-last
-  [generator value-type]
-  (let [stack-type (keyword (str "vector_" value-type))]
-    (prop/for-all [vect (gen/vector generator)]
-                  (let [start-state (state/push-to-stack state/empty-state
-                                                         stack-type
-                                                         vect)
-                        end-state (vector/_last stack-type start-state)]
-                    (or
-                     (and (empty? vect)
-                          (= (state/peek-stack end-state stack-type)
-                             vect))
-                     (and
-                      (= (last vect)
-                         (state/peek-stack end-state (keyword value-type)))
-                      (state/empty-stack? end-state stack-type)))))))
+  [vect value-type]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack state/empty-state
+                                         stack-type
+                                         vect)
+        end-state (vector/_last stack-type start-state)]
+    (or
+     (and (empty? vect)
+          (= (state/peek-stack end-state stack-type)
+             vect))
+     (and
+      (= (last vect)
+         (state/peek-stack end-state (keyword value-type)))
+      (state/empty-stack? end-state stack-type)))))
 
 (defmacro last-spec
   [generator value-type]
   `(defspec ~(symbol (str "last-spec-" value-type))
      100
-     (check-last ~generator ~value-type)))
+     (prop/for-all [vect# (gen/vector ~generator)]
+                   (check-last vect# ~value-type))))
 
 (last-spec gen/small-integer "integer")
 (last-spec gen/double "float")
@@ -149,10 +149,10 @@
   [vect value value-type]
   (let [stack-type (keyword (str "vector_" value-type))
         start-state (state/push-to-stack
-                      (state/push-to-stack state/empty-state
-                                           stack-type
-                                           vect)
-                      (keyword value-type) value)
+                     (state/push-to-stack state/empty-state
+                                          stack-type
+                                          vect)
+                     (keyword value-type) value)
         end-state (vector/_indexof stack-type start-state)
         expected-index (.indexOf vect value)]
     (= expected-index

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -154,26 +154,6 @@
 
 (gen-specs "first" check-first :vector)
 
-;;; vector/_last
-
-(defn check-last
-  [value-type vect]
-  (let [stack-type (keyword (str "vector_" value-type))
-        start-state (state/push-to-stack state/empty-state
-                                         stack-type
-                                         vect)
-        end-state (vector/_last stack-type start-state)]
-    (or
-     (and (empty? vect)
-          (= (state/peek-stack end-state stack-type)
-             vect))
-     (and
-      (= (last vect)
-         (state/peek-stack end-state (keyword value-type)))
-      (state/empty-stack? end-state stack-type)))))
-
-(gen-specs "last" check-last :vector)
-
 ;;; vector/_indexof
 
 (defn check-indexof
@@ -195,6 +175,41 @@
        (state/peek-stack end-state :integer))))
 
 (gen-specs "indexof" check-indexof :vector :item)
+
+;;; vector/_last
+
+(defn check-last
+  [value-type vect]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack state/empty-state
+                                         stack-type
+                                         vect)
+        end-state (vector/_last stack-type start-state)]
+    (or
+     (and (empty? vect)
+          (= (state/peek-stack end-state stack-type)
+             vect))
+     (and
+      (= (last vect)
+         (state/peek-stack end-state (keyword value-type)))
+      (state/empty-stack? end-state stack-type)))))
+
+(gen-specs "last" check-last :vector)
+
+;;; vector/_length
+
+(defn check-length
+  [value-type vect]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack state/empty-state
+                                         stack-type
+                                         vect)
+        end-state (vector/_length stack-type start-state)
+        expected-result (count vect)]
+    (= expected-result
+       (state/peek-stack end-state :integer))))
+
+(gen-specs "length" check-length :vector)
 
 ;;; vector/_subvec
 

--- a/test/propeller/push/instructions/vector_spec.clj
+++ b/test/propeller/push/instructions/vector_spec.clj
@@ -1,0 +1,112 @@
+(ns propeller.push.instructions.vector-spec
+  (:require
+   [clojure.test.check.generators :as gen]
+   [clojure.test.check.properties :as prop]
+   [clojure.test.check.clojure-test :as ct :refer [defspec]]
+   [propeller.push.state :as state]
+   [propeller.push.instructions.vector :as vector]))
+
+(defn check-empty-vector
+  [generator value-type]
+  (let [stack-type (keyword (str "vector_" value-type))]
+    (prop/for-all [vect (gen/vector generator)]
+                  (let [start-state (state/push-to-stack state/empty-state
+                                                         stack-type
+                                                         vect)
+                        end-state (vector/_emptyvector stack-type start-state)]
+                    (= (empty? vect)
+                       (state/peek-stack end-state :boolean))))))
+
+(defmacro empty-vector-spec
+  [generator value-type]
+    `(defspec ~(symbol (str "empty-vector-spec-" value-type))
+       100
+       (check-empty-vector ~generator ~value-type)))
+
+(empty-vector-spec gen/small-integer "integer")
+(empty-vector-spec gen/double "float")
+(empty-vector-spec gen/boolean "boolean")
+(empty-vector-spec gen/string "string")
+
+(defn check-expected-index
+  "Creates an otherwise empty Push state with the given vector on the
+   appropriate vector stack (assumed to be :vector_<value-type>), and
+   the given value on the appropriate stack (determined by value-type).
+   It then runs the vector/_indexof instruction, and confirms that the
+   result (on the :integer stack) is the expected value."
+  [vect value value-type]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack
+                      (state/push-to-stack state/empty-state
+                                           stack-type
+                                           vect)
+                      (keyword value-type) value)
+        end-state (vector/_indexof stack-type start-state)
+        expected-index (.indexOf vect value)]
+    (= expected-index
+       (state/peek-stack end-state :integer))))
+
+(defmacro indexof-spec
+  [generator value-type]
+  `(do
+     (defspec ~(symbol (str "indexof-spec-" value-type))
+       ; Should this be smaller for booleans? (Ditto for below.)
+       100
+       (prop/for-all [vect# (gen/vector ~generator)
+                      value# ~generator]
+                     (check-expected-index vect# value# ~value-type)))
+       ; For float and string vectors, it's rather rare to actually have a random value that
+       ; appears in the vector, so we don't consistently test the case where it should 
+       ; return -1. So maybe we do need a separate test for those? 
+     (defspec ~(symbol (str "indexof-spec-has-value-" value-type))
+       100
+       (prop/for-all [vect# (gen/not-empty (gen/vector ~generator))]
+                     (check-expected-index vect# (rand-nth vect#) ~value-type)))))
+
+(indexof-spec gen/small-integer "integer")
+(indexof-spec gen/double "float")
+(indexof-spec gen/boolean "boolean")
+(indexof-spec gen/string "string")
+
+(defn clean-subvec-bounds
+  [start stop vect-size]
+  (let [start (max 0 start)
+        stop (max 0 stop)
+        start (min start vect-size)
+        stop (min stop vect-size)
+        stop (max start stop)]
+    [start stop]))
+
+(defn check-subvec
+  "Creates an otherwise empty Push state with the given vector on the
+   appropriate vector stack (assumed to be :vector_<value-type>), and
+   the given values on the integer stack.
+   It then runs the vector/_subvec instruction, and confirms that the
+   result (on the :vector_<value-type> stack) is the expected value."
+  [vect start stop value-type]
+  (let [stack-type (keyword (str "vector_" value-type))
+        start-state (state/push-to-stack
+                     (state/push-to-stack
+                      (state/push-to-stack state/empty-state
+                                           stack-type
+                                           vect)
+                      :integer start)
+                     :integer stop)
+        end-state (vector/_subvec stack-type start-state)
+        [cleaned-start cleaned-stop] (clean-subvec-bounds start stop (count vect))
+        expected-subvec (subvec vect cleaned-start cleaned-stop)]
+    (= expected-subvec
+       (state/peek-stack end-state stack-type))))
+
+(defmacro subvec-spec
+  [generator value-type]
+  `(defspec ~(symbol (str "subvec-spec-" value-type))
+     (prop/for-all [vect# (gen/vector ~generator)
+                    start# gen/small-integer
+                    stop# gen/small-integer]
+                   (check-subvec vect# start# stop# ~value-type))))
+
+(subvec-spec gen/small-integer "integer")
+(subvec-spec gen/double "float")
+(subvec-spec gen/boolean "boolean")
+(subvec-spec gen/string "string")


### PR DESCRIPTION
This uses `test.check` to create tests for all of the vector instructions. 

Additionally, @NicMcPhee and I made some changes to the vector instructions based on our findings from the tests. In order to do so, we added the ability for instructions to return `:ignore-instruction` which will cause the interpreter to skip the instruction and keep the state unchanged. The changes to the vector instructions are as follows:

- `_first`, `_last`, `_nth`, and `_set` now ignore the instruction (no stack change) if the vector is empty
- `_replacefirst` used to fail if the item that was to be replaced didn't exist in the vector, now it just returns the vector unchanged
- `_subvec` the start and stopping indices were given in the wrong order, so they have been reversed, additionally, when both the starting index and stopping index were negative, an error would be thrown, which has also been fixed

The tests can be run using `lein test`.