### PR TITLE
Made all training data representations consistent with PSB2

### DIFF
--- a/src/propeller/problems/simple_regression.cljc
+++ b/src/propeller/problems/simple_regression.cljc
@@ -14,10 +14,8 @@
 (def train-and-test-data
   (let [train-inputs (range -10 11)
         test-inputs (concat (range -20 -10) (range 11 21))]
-    {:train {:inputs  train-inputs
-             :outputs (map target-function train-inputs)}
-     :test  {:inputs  test-inputs
-             :outputs (map target-function test-inputs)}}))
+    {:train (map (fn [x] {:input1 (vector x) :output1 (vector (target-function x))}) train-inputs)
+     :test (map (fn [x] {:input1 (vector x) :output1 (vector (target-function x))}) test-inputs)}))
 
 (def instructions
   (list :in1
@@ -39,8 +37,8 @@
   final top item on the INTEGER stack."
   ([argmap data individual]
    (let [program (genome/plushy->push (:plushy individual) argmap)
-         inputs (:inputs data)
-         correct-outputs (:outputs data)
+         inputs (map (fn [x] (first (:input1 x))) data)
+         correct-outputs (map (fn [x] (first (:output1 x))) data)
          outputs (map (fn [input]
                         (state/peek-stack
                           (interpreter/interpret-program

--- a/src/propeller/problems/string_classification.cljc
+++ b/src/propeller/problems/string_classification.cljc
@@ -44,11 +44,11 @@
 
 (def train-and-test-data
   (let [train-inputs ["GCG" "GACAG" "AGAAG" "CCCA" "GATTACA" "TAGG" "GACT"]
-        test-inputs ["GCGT" "GACTTAG" "AGTAAG" "TCCTCA" "GAACA" "AGG" "GAC"]]
-    {:train {:inputs  train-inputs
-             :outputs [false false false false true true true]}
-     :test  {:inputs  test-inputs
-             :outputs [true true true true false false false]}}))
+        test-inputs ["GCGT" "GACTTAG" "AGTAAG" "TCCTCA" "GAACA" "AGG" "GAC"]
+        train-outputs [false false false false true true true]
+        test-outputs [true true true true false false false]]
+    {:train (map (fn [in out] {:input1 (vector in) :output1 (vector out)}) train-inputs train-outputs)
+     :test (map (fn [in out] {:input1 (vector in) :output1 (vector  out)}) test-inputs test-outputs)}))
 
 (defn error-function
   "Finds the behaviors and errors of an individual: Error is 0 if the value and
@@ -57,8 +57,8 @@
   the BOOLEAN stack."
   [argmap data individual]
   (let [program (genome/plushy->push (:plushy individual) argmap)
-        inputs (:inputs data)
-        correct-outputs (:outputs data)
+        inputs (map (fn [x] (first (:input1 x))) data)
+        correct-outputs (map (fn [x] (first (:output1 x))) data)
         outputs (map (fn [input]
                        (state/peek-stack
                          (interpreter/interpret-program

--- a/src/propeller/problems/valiant.cljc
+++ b/src/propeller/problems/valiant.cljc
@@ -19,10 +19,8 @@
                                                   input-indices)))))
         train-inputs (repeatedly num-train rand-vars)
         test-inputs (repeatedly num-test rand-vars)]
-    {:train {:inputs  train-inputs
-             :outputs (map even-parity? train-inputs)}
-     :test  {:inputs  test-inputs
-             :outputs (map even-parity? test-inputs)}}))
+    {:train (map (fn [x] {:input1 x :output1 (vector (even-parity? x))}) train-inputs)
+     :test (map (fn [x] {:input1 x :output1 (vector (even-parity? x))}) test-inputs)}))
 
 (def instructions
   (vec (concat (for [i (range num-vars)] (keyword (str "in" i)))
@@ -38,8 +36,8 @@
 (defn error-function
   [argmap data individual]
   (let [program (genome/plushy->push (:plushy individual) argmap)
-        inputs (:inputs data)
-        correct-outputs (:outputs data)
+        inputs (map (fn [x] (:input1 x)) data)
+        correct-outputs (map (fn [x] (first (:output1 x))) data)
         outputs (map (fn [input]
                        (state/peek-stack
                          (interpreter/interpret-program


### PR DESCRIPTION
They all are now lists of maps.

This change was made ahead of the down-sampled lexicase selection implementation to ensure that case down-sampling can be done in the same way regardless of problem.