### PR TITLE
Fix from string instruction and several PSB2 problems

### DIFF
--- a/src/propeller/problems/PSB2/camel_case.cljc
+++ b/src/propeller/problems/PSB2/camel_case.cljc
@@ -78,19 +78,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj  (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
                         (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/fizz_buzz.cljc
+++ b/src/propeller/problems/PSB2/fizz_buzz.cljc
@@ -46,19 +46,14 @@
                             (:step-limit argmap))
                           :string))
                       inputs)
-         parsed-outputs (map (fn [output]
-                               (try (read-string output)
-                                    #?(:clj (catch Exception e 1000.0)
-                                       :cljs (catch js/Error. e 1000.0))))
-                             outputs)
          errors (map (fn [correct-output output]
                        (if (= output :no-stack-item)
                          10000
-                         (metrics/levenshtein-distance (str correct-output) (str output))))
+                         (metrics/levenshtein-distance correct-output output)))
                      correct-outputs
-                     parsed-outputs)]
+                     outputs)]
      (assoc individual
-       :behaviors parsed-outputs
+       :behaviors outputs
        :errors errors
        :total-error #?(:clj  (apply +' errors)
                        :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/middle_character.cljc
+++ b/src/propeller/problems/PSB2/middle_character.cljc
@@ -47,19 +47,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (if (= output :no-stack-item)
-                                1000.0
-                                output))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
-                        (metrics/levenshtein-distance (str correct-output) (str output))))
+                        (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/middle_character.cljc
+++ b/src/propeller/problems/PSB2/middle_character.cljc
@@ -48,9 +48,9 @@
                          :string))
                      inputs)
         parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj  (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
+                              (if (= output :no-stack-item)
+                                1000.0
+                                output))
                             outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)

--- a/src/propeller/problems/PSB2/spin_words.cljc
+++ b/src/propeller/problems/PSB2/spin_words.cljc
@@ -74,19 +74,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj  (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
                         (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/square_digits.cljc
+++ b/src/propeller/problems/PSB2/square_digits.cljc
@@ -46,19 +46,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
-                        (metrics/levenshtein-distance (str correct-output) (str output))))
+                        (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/substitution_cipher.cljc
+++ b/src/propeller/problems/PSB2/substitution_cipher.cljc
@@ -59,19 +59,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj  (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
-                        (metrics/levenshtein-distance (str correct-output) (str output))))
+                        (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/problems/PSB2/twitter.cljc
+++ b/src/propeller/problems/PSB2/twitter.cljc
@@ -50,19 +50,14 @@
                            (:step-limit argmap))
                          :string))
                      inputs)
-        parsed-outputs (map (fn [output]
-                              (try (read-string output)
-                                   #?(:clj  (catch Exception e 1000.0)
-                                      :cljs (catch js/Error. e 1000.0))))
-                            outputs)
         errors (map (fn [correct-output output]
                       (if (= output :no-stack-item)
                         10000
-                        (metrics/levenshtein-distance (str correct-output) (str output))))
+                        (metrics/levenshtein-distance correct-output output)))
                     correct-outputs
-                    parsed-outputs)]
+                    outputs)]
     (assoc individual
-      :behaviors parsed-outputs
+      :behaviors outputs
       :errors errors
       :total-error #?(:clj  (apply +' errors)
                       :cljs (apply + errors)))))

--- a/src/propeller/push/instructions/numeric.cljc
+++ b/src/propeller/push/instructions/numeric.cljc
@@ -121,9 +121,13 @@
     :name "_from_string"}
   (fn [stack state]
     (make-instruction state
-                      #(try ((if (= stack :integer) int float) (read-string %))
-                            #?(:clj (catch Exception e)
-                               :cljs (catch js/Error. e)))
+                      #(try (if (= stack :integer)
+                             #?(:clj (Integer/parseInt %)
+                                :cljs (js/parseInt %)) 
+                             #?(:clj (Float/parseFloat %) 
+                                :cljs (js/parseFloat %)))
+                            #?(:clj (catch Exception e :ignore-instruction)
+                               :cljs (catch js/Error e :ignore-instruction)))
                       [:string]
                       stack)))
 


### PR DESCRIPTION
Modified the 'from-string' instruction to properly handle different cases and return :no-stack-item when appropriate. Additionally, modified several PSB2 problems to remove the parsed-outputs section. Since the output came from the string stack, parsing them actually returned unhelpful things at times. For example, using 'read-string' on "+1" will only return 1.